### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,10 +176,12 @@ AC_SUBST(PACKAGE_RELEASE,$app_cv_release)
 AC_SUBST(PACKAGE_MAJOR_RELEASE,$app_rls_major)
 AC_SUBST(PACKAGE_MINOR_RELEASE,$app_rls_minor)
 
-rpq_build_date=`LANG=C date`
-rpq_timestamp=`date +%Y%m%d%H%M%S`
-rpq_revision=`date +"%Y%m%d"`
-sccs_date=`date +%Y/%m/%d`
+date="date"
+test -z "$SOURCE_DATE_EPOCH" || date="$date -u -d@$SOURCE_DATE_EPOCH"
+rpq_build_date=`LANG=C $date`
+rpq_timestamp=`$date +%Y%m%d%H%M%S`
+rpq_revision=`$date +"%Y%m%d"`
+sccs_date=`$date +%Y/%m/%d`
 sccs_user=$USER
 
 AC_SUBST(RPQ_BUILD_DATE,$rpq_build_date)


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Note: This date call only works with GNU date. If support for BSD date is important, we can make a more elaborate patch.