### PR TITLE
Use environment compiler flags if set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,10 @@ dnl ---------------------------------------------------------------------------
 
 DLLPREFIX="lib"
 
+AC_SUBST(CFLAGS)
+AC_SUBST(LDFLAGS)
+AC_SUBST(LIBS)
+
 case "$host" in
 	*-mingw32|*-pc-msys)
 		app_cv_osname="windows"


### PR DESCRIPTION
The current logic references `$CFLAGS`, `$LDFLAGS`, `$LIBS`, but they are never initialized, so it ends up never actually consuming them. Ensure they get populated with the values that might be defined in the environment.