### PR TITLE
configure: set gettext version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ conftest.*
 mstest.*
 *.cscope_file_list
 *.orig
+ABOUT-NLS
+intl
+po

--- a/autogen.sh
+++ b/autogen.sh
@@ -35,6 +35,8 @@ fi
 
 automake --add-missing 2> /dev/null | true
 
+autopoint
+
 cd "$olddir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ AM_INIT_AUTOMAKE
 dnl Check for iconv
 AM_ICONV
 
+dnf Set gettext version
+AM_GNU_GETTEXT_VERSION([0.14])
+
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX


### PR DESCRIPTION
When using autoconf 2.71, `./autogen.sh` will fail with
```
$ ./autogen.sh 
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'scripts'.
libtoolize: linking file 'scripts/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: linking file 'm4/libtool.m4'
libtoolize: linking file 'm4/ltoptions.m4'
libtoolize: linking file 'm4/ltsugar.m4'
libtoolize: linking file 'm4/ltversion.m4'
libtoolize: linking file 'm4/lt~obsolete.m4'
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
configure: error: cannot find required auxiliary files: config.rpath
```
Further investigation reveals what's actually failing is `autopoint`:
```
$ autopoint -f
autopoint: *** Missing version: please specify in configure.ac through a line 'AM_GNU_GETTEXT_VERSION(x.yy.zz)' the gettext version the package is using
autopoint: *** Stop.
```
So we set a gettext version in `configure.ac` to make it happy.