### PR TITLE
Fix PA key mapping

### DIFF
--- a/src/core/actions/table.c
+++ b/src/core/actions/table.c
@@ -86,11 +86,11 @@ static int pa1(H3270 *hSession) {
 }
 
 static int pa2(H3270 *hSession) {
-	return lib3270_pakey(hSession,1);
+	return lib3270_pakey(hSession,2);
 }
 
 static int pa3(H3270 *hSession) {
-	return lib3270_pakey(hSession,1);
+	return lib3270_pakey(hSession,3);
 }
 
 /**


### PR DESCRIPTION
I noticed that the `PA1`, `PA2` and `PA3` accelerators in pw3270 all sent the same `PA1` AID to the host. I confirmed by enabling the data stream trace and all accelerators sent the same AID.

With this change the correct AID should be sent.

Great project by the way, I'm just trying it out after using x3270 for many years and it looks to provide a much cleaner interface on modern Linux systems!